### PR TITLE
signal slot connecting to make add layers work

### DIFF
--- a/plugin/MetaSearch/dialogs/maindialog.py
+++ b/plugin/MetaSearch/dialogs/maindialog.py
@@ -30,7 +30,7 @@
 
 import os.path
 
-from PyQt4.QtCore import QSettings, Qt
+from PyQt4.QtCore import QSettings, Qt, SIGNAL, SLOT
 from PyQt4.QtGui import (QApplication, QColor, QCursor, QDialog, QInputDialog,
                          QMessageBox, QTreeWidgetItem, QWidget)
 
@@ -623,6 +623,17 @@ class MetaSearchDialog(QDialog, Ui_MetaSearchDialog):
         # open provider window
         ows_provider = QgsProviderRegistry.instance().selectWidget(stype[2],
                                                                    self)
+        # connect dialog signals to iface slots
+        if service_type == 'OGC:WMS/OGC:WMTS':
+            ows_provider.connect(
+                ows_provider, SIGNAL('addRasterLayer(QString, QString, QString)'), 
+                self.iface, SLOT('addRasterLayer(QString, QString, QString)'))
+        elif service_type == 'OGC:WFS':
+            # TODO probably connect like with WMS
+            pass
+        elif service_type == 'OGC:WCS':
+            # TODO probably connect like with WMS (or exact same signal?)
+            pass
         ows_provider.setModal(False)
         ows_provider.show()
 


### PR DESCRIPTION
this is the example to make the add layer work, but the wfs and wcs part is not working but that is because the code for finding the server tab and then the connections combobox is specific for the wms dialog, so should be fixed for wfs

other point: wmts seems also to be broken...
