### PR TITLE
add different save ows name strategies

### DIFF
--- a/plugin/MetaSearch/ui/maindialog.ui
+++ b/plugin/MetaSearch/ui/maindialog.ui
@@ -6,18 +6,28 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>537</width>
+    <width>598</width>
     <height>650</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>MetaSearch client</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="1" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="tabSearch">
       <attribute name="title">
@@ -254,6 +264,20 @@
        <string>Services</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout">
+       <item row="4" column="0" colspan="5">
+        <widget class="QTextBrowser" name="textMetadata">
+         <property name="openExternalLinks">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="3" colspan="2">
+        <widget class="QPushButton" name="btnAddDefault">
+         <property name="text">
+          <string>Add default services</string>
+         </property>
+        </widget>
+       </item>
        <item row="0" column="0" colspan="5">
         <widget class="QComboBox" name="cmbConnectionsServices"/>
        </item>
@@ -299,20 +323,6 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="0" colspan="5">
-        <widget class="QTextBrowser" name="textMetadata">
-         <property name="openExternalLinks">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="3" colspan="2">
-        <widget class="QPushButton" name="btnAddDefault">
-         <property name="text">
-          <string>Add default services</string>
-         </property>
-        </widget>
-       </item>
        <item row="2" column="3">
         <widget class="QPushButton" name="btnLoad">
          <property name="text">
@@ -322,16 +332,75 @@
        </item>
       </layout>
      </widget>
-    </widget>
-   </item>
-   <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Close</set>
-     </property>
+     <widget class="QWidget" name="tab">
+      <attribute name="title">
+       <string>Settings</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_3">
+       <item row="1" column="0">
+        <widget class="QGroupBox" name="groupBox_3">
+         <property name="title">
+          <string>Connection naming</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout">
+          <item>
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>When saving the connection of an OWS service</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="titleAsk">
+            <property name="text">
+             <string>Use the OWS Service Title and ask before overwriting</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+            <attribute name="buttonGroup">
+             <string notr="true">radioUseAsName</string>
+            </attribute>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="titleNoAsk">
+            <property name="text">
+             <string>Use the OWS Service Title and always overwrite if already available</string>
+            </property>
+            <attribute name="buttonGroup">
+             <string notr="true">radioUseAsName</string>
+            </attribute>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="tempName">
+            <property name="text">
+             <string>Use a temporary name, which you can change later</string>
+            </property>
+            <attribute name="buttonGroup">
+             <string notr="true">radioUseAsName</string>
+            </attribute>
+           </widget>
+          </item>
+          <item>
+           <spacer name="verticalSpacer">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>
@@ -371,4 +440,7 @@
    </hints>
   </connection>
  </connections>
+ <buttongroups>
+  <buttongroup name="radioUseAsName"/>
+ </buttongroups>
 </ui>

--- a/plugin/MetaSearch/ui/maindialog.ui
+++ b/plugin/MetaSearch/ui/maindialog.ui
@@ -11,23 +11,13 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MetaSearch client</string>
+   <string>MetaSearch</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout_2">
-   <item row="1" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Close</set>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tabSearch">
       <attribute name="title">
@@ -264,20 +254,6 @@
        <string>Services</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout">
-       <item row="4" column="0" colspan="5">
-        <widget class="QTextBrowser" name="textMetadata">
-         <property name="openExternalLinks">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="3" colspan="2">
-        <widget class="QPushButton" name="btnAddDefault">
-         <property name="text">
-          <string>Add default services</string>
-         </property>
-        </widget>
-       </item>
        <item row="0" column="0" colspan="5">
         <widget class="QComboBox" name="cmbConnectionsServices"/>
        </item>
@@ -323,6 +299,20 @@
          </property>
         </widget>
        </item>
+       <item row="3" column="0" colspan="5">
+        <widget class="QTextBrowser" name="textMetadata">
+         <property name="openExternalLinks">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="3" colspan="2">
+        <widget class="QPushButton" name="btnAddDefault">
+         <property name="text">
+          <string>Add default services</string>
+         </property>
+        </widget>
+       </item>
        <item row="2" column="3">
         <widget class="QPushButton" name="btnLoad">
          <property name="text">
@@ -332,75 +322,80 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="tab">
+     <widget class="QWidget" name="tabSettings">
       <attribute name="title">
        <string>Settings</string>
       </attribute>
-      <layout class="QGridLayout" name="gridLayout_3">
-       <item row="1" column="0">
-        <widget class="QGroupBox" name="groupBox_3">
-         <property name="title">
-          <string>Connection naming</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout">
-          <item>
-           <widget class="QLabel" name="label_5">
-            <property name="text">
-             <string>When saving the connection of an OWS service</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QRadioButton" name="titleAsk">
-            <property name="text">
-             <string>Use the OWS Service Title and ask before overwriting</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-            <attribute name="buttonGroup">
-             <string notr="true">radioUseAsName</string>
-            </attribute>
-           </widget>
-          </item>
-          <item>
-           <widget class="QRadioButton" name="titleNoAsk">
-            <property name="text">
-             <string>Use the OWS Service Title and always overwrite if already available</string>
-            </property>
-            <attribute name="buttonGroup">
-             <string notr="true">radioUseAsName</string>
-            </attribute>
-           </widget>
-          </item>
-          <item>
-           <widget class="QRadioButton" name="tempName">
-            <property name="text">
-             <string>Use a temporary name, which you can change later</string>
-            </property>
-            <attribute name="buttonGroup">
-             <string notr="true">radioUseAsName</string>
-            </attribute>
-           </widget>
-          </item>
-          <item>
-           <spacer name="verticalSpacer">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </widget>
-       </item>
-      </layout>
+      <widget class="QGroupBox" name="saveStrategyGroup">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>10</y>
+         <width>558</width>
+         <height>548</height>
+        </rect>
+       </property>
+       <property name="title">
+        <string>Connection naming</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_3">
+        <item>
+         <widget class="QLabel" name="lblSaveStrategy">
+          <property name="text">
+           <string>When saving the connection of an OWS service</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="radioTitleAsk">
+          <property name="text">
+           <string>Use the OWS Service Title and ask before overwriting</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="radioTitleNoAsk">
+          <property name="text">
+           <string>Use the OWS Service Title and always overwrite if already available</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="radioTempName">
+          <property name="text">
+           <string>Use a temporary name, which you can change later</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="verticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
      </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close</set>
+     </property>
     </widget>
    </item>
   </layout>
@@ -440,7 +435,4 @@
    </hints>
   </connection>
  </connections>
- <buttongroups>
-  <buttongroup name="radioUseAsName"/>
- </buttongroups>
 </ui>


### PR DESCRIPTION
became a little more complex then I hoped, please review and test

one bug fixed:
https://github.com/geopython/MetaSearch/blob/master/plugin/MetaSearch/dialogs/maindialog.py#L652
saving a Setting with a key part like 'OGC:WMS/OGC:WMTS' silently failed. 
So I changed it to a simpler: "wms from MetaSearch"

Pressing the enter button now closed the dialog with me (as I had earlier myself with another plugin). Fixed with line 105
