### PR TITLE
fixing some tx stuff

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -7,21 +7,41 @@ file_filter = docs/locale/<lang>/LC_MESSAGES/index.po
 source_file = docs/locale/en/LC_MESSAGES/index.po
 source_lang = en
 type = PO
+trans.nl = docs/locale/nl/LC_MESSAGES/index.po
+trans.it = docs/locale/it/LC_MESSAGES/index.po
+trans.fr = docs/locale/fr/LC_MESSAGES/index.po
+trans.cs = docs/locale/cs/LC_MESSAGES/index.po
+trans.de = docs/locale/de/LC_MESSAGES/index.po
 
 [MetaSearch.docs_howto]
 file_filter = docs/locale/<lang>/LC_MESSAGES/howto.po
 source_file = docs/locale/en/LC_MESSAGES/howto.po
 source_lang = en
 type = PO
+trans.nl = docs/locale/nl/LC_MESSAGES/howto.po
+trans.it = docs/locale/it/LC_MESSAGES/howto.po
+trans.fr = docs/locale/fr/LC_MESSAGES/howto.po
+trans.cs = docs/locale/cs/LC_MESSAGES/howto.po
+trans.de = docs/locale/de/LC_MESSAGES/howto.po
 
 [MetaSearch.plugin_core]
 file_filter = plugin/MetaSearch/locale/<lang>/LC_MESSAGES/ui.ts
 source_file = plugin/MetaSearch/locale/en/LC_MESSAGES/ui.ts
 source_lang = en
 type = QT
+trans.nl = plugin/MetaSearch/locale/nl/LC_MESSAGES/ui.ts
+trans.it = plugin/MetaSearch/locale/it/LC_MESSAGES/ui.ts
+trans.fr = plugin/MetaSearch/locale/fr/LC_MESSAGES/ui.ts
+trans.cs = plugin/MetaSearch/locale/cs/LC_MESSAGES/ui.ts
+trans.de = plugin/MetaSearch/locale/de/LC_MESSAGES/ui.ts
 
 [MetaSearch.plugin_templates]
 file_filter = plugin/MetaSearch/locale/<lang>/LC_MESSAGES/templates.po
 source_file = plugin/MetaSearch/locale/en/LC_MESSAGES/templates.po
 source_lang = en
 type = PO
+trans.nl = plugin/MetaSearch/locale/nl/LC_MESSAGES/templates.po
+trans.it = plugin/MetaSearch/locale/it/LC_MESSAGES/templates.po
+trans.fr = plugin/MetaSearch/locale/fr/LC_MESSAGES/templates.po
+trans.cs = plugin/MetaSearch/locale/cs/LC_MESSAGES/templates.po
+trans.de = plugin/MetaSearch/locale/de/LC_MESSAGES/templates.po

--- a/plugin/MetaSearch/plugin.py
+++ b/plugin/MetaSearch/plugin.py
@@ -50,7 +50,10 @@ class MetaSearchPlugin(object):
 
         LOGGER.debug('Setting up i18n')
 
-        locale_name = str(QLocale.system().name()).split('_')[0]
+        # TODO: does this work for locales like: pt_BR ?
+        locale_name = QSettings().value("locale/userLocale")[0:2]
+        # this one below does not pick up when you load QGIS with --lang param
+#        locale_name = str(QLocale.system().name()).split('_')[0]
 
         LOGGER.debug('Locale name: %s', locale_name)
 


### PR DESCRIPTION
plz check this

I've updated .tx/config so a 'tx pull -a' retrieves all languages from transifex
(note: paver clean also removes them all. Maybe leave them in the dirs, either put them in .gitignore or just check them in periodically?)

after paver extract_messages and paver compile_messages the po stuff is compiled
but the tx files are not... seems something to do with missing info in .pro file?? When I make a 'release' file with linguist (just load the ts file, and do File/Release, a ui.qm file will be generated next to ts file). 
The dialog will be translated (small fix in plugin .py to make 'qgis --lang it' work)
Q1: how is the pro file generated (and can it be fixed so all locales will have a release)?
Q2: how will the loading of the translated docs work?
