### PR TITLE
show available download for INSPIRE atom feed in dialog

### DIFF
--- a/plugin/MetaSearch/link_types.py
+++ b/plugin/MetaSearch/link_types.py
@@ -47,3 +47,7 @@ WCS_LINK_TYPES = [
     'urn:x-esri:specification:ServiceType:wcs:url',
     'urn:x-esri:specification:ServiceType:Gmd:URL.wcs'
 ]
+
+DATA_LINK_TYPES = [
+    'INSPIRE Atom'
+]

--- a/plugin/MetaSearch/resources/templates/inspire_atom_data_dc.html
+++ b/plugin/MetaSearch/resources/templates/inspire_atom_data_dc.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="{{ language }}">
+    <head>
+        <meta charset="utf-8"/>
+        <title>{{ gettext('Downloadable data') }}</title>
+        <style type="text/css">
+            body, h3 {
+                background-color: #ffffff;
+                font-family: arial, verdana, sans-serif;
+                text-align: left;
+                float: left;
+            }
+            header {
+                display: inline-block;
+            }
+            table {
+                margin-top: 15px;
+                margin-bottom: 15px;
+            }
+            li {
+                margin-bottom: 20px;
+                font-size: 12px;
+            }
+        </style>
+    </head>
+    <body>
+        <header>
+            <h3>{{ gettext('Data feed') }} (<a href="{{ obj['feed']['link'] }}">{{ gettext('View raw feed') }}</a>)</h3>
+        </header>
+        <section id="record-metadata">
+            <table>
+                <tr>
+                    <td><b>{{ gettext('Title') }}</b></td>
+                    <td>{{ obj['feed']['title'] }}</td>
+                </tr>
+                <tr>
+                    <td>&nbsp;</td>
+                    <td>{{ obj['feed']['subtitle'] }}</td>
+                </tr>
+                <tr>
+                    <td><b>{{ gettext('Contact') }}</b></td>
+                    <td>{{ obj['feed']['author'] }}</td>
+                </tr>
+            </table>
+        </section>
+        <section id="links">
+            <h4>{{ gettext('Downloads') }}</h4>
+            <ul>
+            {% for entry in obj.entries %}
+                <li><a href="{{ entry['link'] }}">{{ entry['title'] }}</a><br/>
+                    {{ entry['summary'] }}<br/>
+                    {{ entry['updated'] }}<br/>
+                    {{ entry['georss_polygon'] if entry['georss_polygon'] }}
+                    {{ entry['georss_point'] if entry['georss_point'] }}
+                </li>
+            {% endfor %}
+            </ul>
+        </section>
+    </body>
+</html>

--- a/plugin/MetaSearch/ui/maindialog.ui
+++ b/plugin/MetaSearch/ui/maindialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>608</width>
+    <width>653</width>
     <height>550</height>
    </rect>
   </property>
@@ -27,7 +27,7 @@
        <item>
         <widget class="QGroupBox" name="groupBox">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
@@ -35,199 +35,160 @@
          <property name="title">
           <string>Find</string>
          </property>
-         <widget class="QLabel" name="label_3">
-          <property name="geometry">
-           <rect>
-            <x>7</x>
-            <y>33</y>
-            <width>71</width>
-            <height>18</height>
-           </rect>
-          </property>
-          <property name="text">
-           <string>Keywords</string>
-          </property>
-         </widget>
-         <widget class="QLineEdit" name="leKeywords">
-          <property name="geometry">
-           <rect>
-            <x>90</x>
-            <y>30</y>
-            <width>191</width>
-            <height>26</height>
-           </rect>
-          </property>
-         </widget>
-         <widget class="QPushButton" name="btnCanvasBbox">
-          <property name="geometry">
-           <rect>
-            <x>290</x>
-            <y>90</y>
-            <width>131</width>
-            <height>27</height>
-           </rect>
-          </property>
-          <property name="text">
-           <string>Map extent</string>
-          </property>
-         </widget>
-         <widget class="QComboBox" name="cmbConnectionsSearch">
-          <property name="geometry">
-           <rect>
-            <x>340</x>
-            <y>30</y>
-            <width>231</width>
-            <height>27</height>
-           </rect>
-          </property>
-         </widget>
-         <widget class="QLabel" name="label">
-          <property name="geometry">
-           <rect>
-            <x>250</x>
-            <y>30</y>
-            <width>78</width>
-            <height>31</height>
-           </rect>
-          </property>
-          <property name="text">
-           <string>        From</string>
-          </property>
-         </widget>
-         <widget class="QPushButton" name="btnGlobalBbox">
-          <property name="geometry">
-           <rect>
-            <x>290</x>
-            <y>60</y>
-            <width>131</width>
-            <height>27</height>
-           </rect>
-          </property>
-          <property name="text">
-           <string>Set global</string>
-          </property>
-         </widget>
-         <widget class="QPushButton" name="btnSearch">
-          <property name="geometry">
-           <rect>
-            <x>430</x>
-            <y>90</y>
-            <width>141</width>
-            <height>27</height>
-           </rect>
-          </property>
-          <property name="text">
-           <string>Search</string>
-          </property>
-         </widget>
-         <widget class="QWidget" name="layoutWidget">
-          <property name="geometry">
-           <rect>
-            <x>10</x>
-            <y>60</y>
-            <width>272</width>
-            <height>58</height>
-           </rect>
-          </property>
-          <layout class="QGridLayout" name="gridLayout_2">
-           <item row="0" column="0">
-            <widget class="QLabel" name="label_4">
-             <property name="text">
-              <string>Xmax</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QLineEdit" name="leEast">
-             <property name="enabled">
-              <bool>true</bool>
-             </property>
-             <property name="minimumSize">
-              <size>
-               <width>85</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>180</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="2">
-            <widget class="QLabel" name="label_7">
-             <property name="text">
-              <string>Ymax</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="3" colspan="2">
-            <widget class="QLineEdit" name="leNorth">
-             <property name="minimumSize">
-              <size>
-               <width>85</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>90</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="label_6">
-             <property name="text">
-              <string>Xmin</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="QLineEdit" name="leWest">
-             <property name="minimumSize">
-              <size>
-               <width>85</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>-180</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="2">
-            <widget class="QLabel" name="label_8">
-             <property name="text">
-              <string>Ymin</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="3" colspan="2">
-            <widget class="QLineEdit" name="leSouth">
-             <property name="minimumSize">
-              <size>
-               <width>85</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>-90</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-         <zorder>label_3</zorder>
-         <zorder>leKeywords</zorder>
-         <zorder>btnCanvasBbox</zorder>
-         <zorder>cmbConnectionsSearch</zorder>
-         <zorder>label</zorder>
-         <zorder>btnGlobalBbox</zorder>
-         <zorder>btnSearch</zorder>
-         <zorder>layoutWidget</zorder>
-         <zorder>groupBox_2</zorder>
+         <layout class="QGridLayout" name="gridLayout_3">
+          <item row="0" column="1">
+           <widget class="QLineEdit" name="leKeywords">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_3">
+            <property name="text">
+             <string>Keywords</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="3" colspan="2">
+           <widget class="QPushButton" name="btnCanvasBbox">
+            <property name="text">
+             <string>Map extent</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="5">
+           <widget class="QPushButton" name="btnSearch">
+            <property name="text">
+             <string>Search</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="3" colspan="2">
+           <widget class="QPushButton" name="btnGlobalBbox">
+            <property name="text">
+             <string>Set global</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="3" colspan="3">
+           <widget class="QComboBox" name="cmbConnectionsSearch">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0" rowspan="2" colspan="3">
+           <layout class="QGridLayout" name="gridLayout_2">
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_4">
+              <property name="text">
+               <string>Xmax</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QLineEdit" name="leEast">
+              <property name="enabled">
+               <bool>true</bool>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>85</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>180</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="2">
+             <widget class="QLabel" name="label_7">
+              <property name="text">
+               <string>Ymax</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="3" colspan="2">
+             <widget class="QLineEdit" name="leNorth">
+              <property name="minimumSize">
+               <size>
+                <width>85</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>90</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="label_6">
+              <property name="text">
+               <string>Xmin</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QLineEdit" name="leWest">
+              <property name="minimumSize">
+               <size>
+                <width>85</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>-180</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="2">
+             <widget class="QLabel" name="label_8">
+              <property name="text">
+               <string>Ymin</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="3" colspan="2">
+             <widget class="QLineEdit" name="leSouth">
+              <property name="minimumSize">
+               <size>
+                <width>85</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>-90</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="0" column="2">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>        From</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
        <item>
         <widget class="QGroupBox" name="groupBox_2">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="title">
           <string>Results</string>
          </property>
@@ -306,6 +267,12 @@
           </item>
           <item row="4" column="0">
            <widget class="QPushButton" name="btnAddToWms">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
             <property name="text">
              <string>Add WMS/WMTS</string>
             </property>
@@ -313,6 +280,12 @@
           </item>
           <item row="4" column="1">
            <widget class="QPushButton" name="btnAddToWfs">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
             <property name="minimumSize">
              <size>
               <width>145</width>
@@ -339,6 +312,12 @@
           </item>
           <item row="4" column="3">
            <widget class="QPushButton" name="btnAddToWcs">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
             <property name="text">
              <string>Add WCS</string>
             </property>
@@ -357,6 +336,19 @@
             </property>
            </widget>
           </item>
+          <item row="4" column="4">
+           <widget class="QPushButton" name="btnData">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Data</string>
+            </property>
+           </widget>
+          </item>
          </layout>
          <zorder>treeRecords</zorder>
          <zorder>lblResults</zorder>
@@ -368,6 +360,7 @@
          <zorder>btnLast</zorder>
          <zorder>btnAddToWcs</zorder>
          <zorder>btnNext</zorder>
+         <zorder>btnData</zorder>
         </widget>
        </item>
       </layout>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Jinja2==2.7.2
 OWSLib==0.8.6
 pygments==1.6
+feedparser


### PR DESCRIPTION
fixed some dialog issues, and added a 'Data' button, which get's enable when you have a 'INSPIRE Atom' link type available in your record.

These should link to a (geo)rss feed link, one like: http://geodata.nationaalgeoregister.nl/ahn2/atom/ahn2_uitgefilterd.xml
Which is being loaded and parsed using 'feedparser' and presented in a Data feed dialog (html), containing all links of the downloads (plus some other data).

The original idea was to show the polygons of every download IN the qgis canvas, but currently all downloads have the same extent (instead of the extent of the data).

Anyway: using the 'dutch nationaal georegister' and searching for 'ahn2' is the easiest test.
Nice thing about 'INSPIRE Atom'-type links is that you always now that you get an atom-feed. Other data types like: 'download' or 'access-link' are just to different in types to what they link...

Anyway, with me it look like this:
![screenshot from 2014-03-31 17 26 32](https://cloud.githubusercontent.com/assets/731673/2569152/dabc9f0a-b8e9-11e3-95e8-35ca95a66ce2.png)
